### PR TITLE
If we're logging an error and then returning, raise an exception instead

### DIFF
--- a/MyClient.py
+++ b/MyClient.py
@@ -160,7 +160,12 @@ Chat, explore, and let your fins grow — your journey through the glittering oc
                 await channel.send(to_send)
 
     async def ensure_react_roles_message(self, guild: discord.Guild):
-        await self.reaction_handler.ensure_react_roles_message_internal(guild=guild, config=config)
+        try:
+            await self.reaction_handler.ensure_react_roles_message_internal(guild=guild, config=config)
+        except (KeyError, ValueError, LookupError) as e:
+            logging.error(f"Failed to ensure react roles message(s) exist. Inner error:\n{e}")
+        except Exception as e:
+            raise e
 
     async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
         await self.reaction_handler.on_raw_reaction_add_internal(payload=payload, config=config)

--- a/handlers/reactions.py
+++ b/handlers/reactions.py
@@ -15,8 +15,7 @@ class reaction_handler:
     async def ensure_react_roles_message_internal(self, config: AppConfig, guild: discord.Guild):
         # check for guild config, if none found then skip
         if not is_guild_in_config(guild_id=guild.id, config=config):
-            logging.error(f"Guild {guild.name} is not in the config. Skipping")
-            return
+            raise ValueError(f"Guild {guild.name} is not in the config. Skipping")
 
         id_to_name: dict = {int(v): k for k, v in config.guilds.items()}
         guild_name: str = id_to_name.get(guild.id)
@@ -26,9 +25,8 @@ class reaction_handler:
         # print(react_role_messages)
 
         if not is_rr_message_id_in_config(guild_name=guild_name, config=config):
-            logging.error(f"Guild {guild.name} is does not have a react roles message ID Key")
-            return        
-
+            raise KeyError(f"Guild {guild.name} does not have a react roles message ID Key")
+        
         for rr_message in react_role_messages:
             # print(react_role_messages[rr_message])
 
@@ -75,14 +73,10 @@ class reaction_handler:
                     except discord.HTTPException:
                         logging.error(f"[RR could not edit react-roles message {rr_message} in {guild_name}]")
                 # ---------------------------------------------------------------------------------------------
-                
-                
                 continue
-            
 
             if channel is None:
-                logging.error(f"[RR] No valid channel configured for {guild_name}")
-                return
+                raise LookupError(f"[RR] No valid channel configured for {guild_name}")
 
             mapping = self.ROLES_PER_GUILD.get(guild.id).get(rr_message)
             # print("current mapping: ",mapping)


### PR DESCRIPTION
General rule of thumb when error handling:
* Catch what you can anticipate
* Handle whatever isn't execution-blocking
* Raise when further execution of the unit is pointless
* Move up one unit and repeat (catch, handle, raise)
* Only completely unexpected outcomes will raise all the way to a crash, which you want! Never continue operating in an undefined state! That's how you do you unrecoverable damage!